### PR TITLE
Errors now return non-zero on failure.

### DIFF
--- a/CyLR/src/Program.cs
+++ b/CyLR/src/Program.cs
@@ -11,7 +11,7 @@ namespace CyLR
 {
     internal static class Program
     {
-        private static void Main(string[] args)
+        private static int Main(string[] args)
         {
             Arguments arguments;
             try
@@ -21,18 +21,18 @@ namespace CyLR
             catch (ArgumentException e)
             {
                 Console.WriteLine(e.Message);
-                return;
+                return 1;
             }
             catch (Exception e)
             {
                 Console.WriteLine($"Unknown error while parsing arguments: {e.Message}");
-                return;
+                return 0;
             }
 
             if (arguments.HelpRequested)
             {
                 Console.WriteLine(arguments.GetHelp(arguments.HelpTopic));
-                return;
+                return 0;
             }
 
             List<string> paths;
@@ -43,7 +43,7 @@ namespace CyLR
             catch (Exception e)
             {
                 Console.WriteLine($"Error occured while collecting files:\n{e}");
-                return;
+                return 1;
             }
 
 
@@ -76,7 +76,9 @@ namespace CyLR
             catch (Exception e)
             {
                 Console.WriteLine($"Error occured while collecting files:\n{e}");
+                return 1;
             }
+            return 0;
         }
 
         /// <summary>


### PR DESCRIPTION
This allows CyLR to behave better in scripts that care if it succeeded or not.

For example:
`CyLR.exe && sftp HOST-NAME.zip user@someserver.com`
will now no longer execute the sftp if it had failed.